### PR TITLE
Refactored WAValidator

### DIFF
--- a/src/wallet_address_validator.js
+++ b/src/wallet_address_validator.js
@@ -14,49 +14,50 @@
 
     var DEFAULT_CURRENCY_NAME = 'bitcoin',
         DEFAULT_NETWORK_TYPE = 'prod';
-
-    var WAValidator = {
-        getAddressType: function (address) {
-            var decoded;
-            try {
-                decoded = base58.decode(address);
-            } catch (e) {
-                // if decoding fails, assume invalid address
-                return null;
-            }
-
-            var length = decoded.length;
-
-            // should be 25 bytes per btc address spec
-            if (length != 25) {
-                return null;
-            }
-
-            var checksum = cryptoUtils.toHex(decoded.slice(length - 4, length)),
-                body = cryptoUtils.toHex(decoded.slice(0, length - 4)),
-                goodChecksum = cryptoUtils.sha256(cryptoUtils.sha256(body)).substr(0, 8);
-
-            return checksum === goodChecksum ? cryptoUtils.toHex(decoded.slice(0, 1)) : null;
-        },
-
-        validate: function (address, currencyNameOrSymbol, networkType) {
-            currencyNameOrSymbol = currencyNameOrSymbol || DEFAULT_CURRENCY_NAME;
-            networkType = networkType || DEFAULT_NETWORK_TYPE;
-
-            var correctAddressTypes,
-                currency = currencies.getByNameOrSymbol(currencyNameOrSymbol),
-                addressType = this.getAddressType(address);
-            
-            if(networkType === 'prod' || networkType === 'testnet'){
-                correctAddressTypes = currency.addressTypes[networkType]
-            } else {
-                correctAddressTypes = currency.addressTypes.prod.concat(currency.addressTypes.testnet);
-            }
-
-            return correctAddressTypes.indexOf(addressType) >= 0;
+    
+    function getAddressType (address) {
+        var decoded;
+        try {
+            decoded = base58.decode(address);
+        } catch (e) {
+            // if decoding fails, assume invalid address
+            return null;
         }
+
+        var length = decoded.length;
+
+        // should be 25 bytes per btc address spec
+        if (length != 25) {
+            return null;
+        }
+
+        var checksum = cryptoUtils.toHex(decoded.slice(length - 4, length)),
+            body = cryptoUtils.toHex(decoded.slice(0, length - 4)),
+            goodChecksum = cryptoUtils.sha256(cryptoUtils.sha256(body)).substr(0, 8);
+
+        return checksum === goodChecksum ? cryptoUtils.toHex(decoded.slice(0, 1)) : null;
     };
 
+    function validate (address, currencyNameOrSymbol, networkType) {
+        currencyNameOrSymbol = currencyNameOrSymbol || DEFAULT_CURRENCY_NAME;
+        networkType = networkType || DEFAULT_NETWORK_TYPE;
+
+        var correctAddressTypes,
+            currency = currencies.getByNameOrSymbol(currencyNameOrSymbol),
+            addressType = this.getAddressType(address);
+
+        if(networkType === 'prod' || networkType === 'testnet'){
+            correctAddressTypes = currency.addressTypes[networkType]
+        } else {
+            correctAddressTypes = currency.addressTypes.prod.concat(currency.addressTypes.testnet);
+        }
+
+        return correctAddressTypes.indexOf(addressType) >= 0;
+    };
+    var WAValidator = {
+        getAddressType: getAddressType,
+        validate: validate
+    };
     // export WAValidator module
     if(isNode) {
         module.exports = WAValidator;
@@ -64,5 +65,3 @@
         window.WAValidator = WAValidator;
     }
 })(typeof module !== 'undefined' && typeof module.exports !== 'undefined');
-
-


### PR DESCRIPTION
Needed to be able to reassign methods by reference, as in:
`validateBase58Address = require('wallet-address-validator').validate`
Presently, this pattern fails on getAddressType not being defined. Hoisting the methods to functions and assigning them to the WAValidator object by reference solves the issue.